### PR TITLE
- Allows arch 'x86_64' to use gcc instead of clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ ARCH=$(shell uname -m)
 
 ifeq ($(ARCH), armv6l)
 CC = gcc
-else
+elif ($(ARCH), x86_64)
+CC = gcce
+lse
 CC = clang
 endif
 ASAN = 0

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ ARCH=$(shell uname -m)
 ifeq ($(ARCH), armv6l)
 CC = gcc
 elif ($(ARCH), x86_64)
-CC = gcce
-lse
+CC = gcc
+else
 CC = clang
 endif
 ASAN = 0


### PR DESCRIPTION
resolves #21 
